### PR TITLE
website: Note `--locale en` for local development

### DIFF
--- a/website/README.md
+++ b/website/README.md
@@ -10,11 +10,21 @@ npm ci
 
 ## Local Development
 
+Japanese page:
+
 ```bash
 npm run start
 ```
 
+English page:
+
+```bash
+npm run start -- --locale en
+```
+
 This command starts a local development server and opens up a browser window. Most changes are reflected live without having to restart the server.
+
+**Note that the dev server can only serve one locale at a time.**
 
 ## Build
 


### PR DESCRIPTION
Since the default locale is Japanese, this is not necessary for Japanese.
For English, we need to pass the `--locale en` option to `start`.

https://docusaurus.io/docs/i18n/tutorial#start-your-site