### PR TITLE
ci: Don't trigger CI jobs from Copilot

### DIFF
--- a/.github/workflows/website.yaml
+++ b/.github/workflows/website.yaml
@@ -17,6 +17,7 @@ on:
   push:
     branches:
       - '**'
+      - '!copilot/**'
       - '!dependabot/**'
   pull_request:
 concurrency:


### PR DESCRIPTION
They are redundant because we use PR for CI jobs.